### PR TITLE
[36기 임채동] Fix: Filter 체크박스 해제 시 기존 데이터 나오도록 변경

### DIFF
--- a/src/components/Nav/NavBottomContainer/NavBottomContainer.scss
+++ b/src/components/Nav/NavBottomContainer/NavBottomContainer.scss
@@ -16,6 +16,7 @@
     .navIconWrapper {
       @include flex(space-between, center);
       width: 1140px;
+      height: 100%;
 
       .menu {
         padding: 20px;

--- a/src/components/Product/Product.js
+++ b/src/components/Product/Product.js
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { API } from '../../config.js';
 import { appendComma, goToUrl } from '../../utils.js';
 import './Product.scss';

--- a/src/pages/ProductsList/FilterMenu/FilterMenu.js
+++ b/src/pages/ProductsList/FilterMenu/FilterMenu.js
@@ -1,14 +1,23 @@
 import { useState } from 'react';
 import './FilterMenu.scss';
 
-function FilterMenu({ title, list, handleChangeFilter }) {
+function FilterMenu({
+  title,
+  list,
+  handleChangeFilter,
+  setProductsList,
+  initialProductsList,
+}) {
   const [isMenuOpened, setIsMenuOpened] = useState(false);
   const [checkedBox, setCheckedBox] = useState('');
 
   const handleClickOpenBtn = e => setIsMenuOpened(prev => !prev);
 
   const handleCheckBox = e => {
-    clickCheck(e.target);
+    const isFilterCanceled = clickCheck(e.target);
+    if (isFilterCanceled) {
+      return;
+    }
     handleChangeFilter(e);
   };
 
@@ -19,11 +28,13 @@ function FilterMenu({ title, list, handleChangeFilter }) {
 
     if (checkedBox === target.value) {
       setCheckedBox('');
-      return;
+      setProductsList(initialProductsList);
+      return true;
     }
 
     target.checked = true;
     setCheckedBox(target.value);
+    return false;
   }
 
   return (

--- a/src/pages/ProductsList/ProductsList.js
+++ b/src/pages/ProductsList/ProductsList.js
@@ -11,6 +11,7 @@ import './ProductsList.scss';
 function ProductsList() {
   const navigate = useNavigate();
   const [productsList, setProductsList] = useState([]);
+  const [initialProductsList, setInitialProductsList] = useState([]);
   const [selectedOrder, setSelectedOrder] = useState(ORDER_LIST[0]);
   const [isOpenedOrder, setIsOpenedOrder] = useState(false);
 
@@ -38,6 +39,7 @@ function ProductsList() {
     };
     const uri = `${API.MAIN}/categories/${categoryId}/${CATEGORY_ID_MAP[categoryId]}/${typeId}`;
     fetchData(uri, options, setProductsList);
+    fetchData(uri, options, setInitialProductsList);
   }, [categoryId, typeId]);
 
   const handleChange = e => {
@@ -175,6 +177,8 @@ function ProductsList() {
                   <FilterMenu
                     key={title}
                     handleChangeFilter={handleChangeFilter}
+                    initialProductsList={initialProductsList}
+                    setProductsList={setProductsList}
                     title={title}
                     list={list}
                   />


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 필터링 체크 박스 해제 시 기존 데이터로 돌아가도록 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 
- 상품 전체 리스트를 Fetch할 때, initialProductsList State에 데이터를 저장해둔다.
- handleCheckBox 실행 될 때, 기존에 체크되어 있는지 확인한다.
- 체크 되어 있는게 해제되는 경우, productsList 데이터에 initialProductsList를 setState해준다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 머지 이후에 확인 과정에서 Fix되어야할 버그들이 많음을 배웠습니다.

<br />

## :: 기타 질문 및 특이 사항
